### PR TITLE
Adding missing license header in CarbonMessage class and removing blanks

### DIFF
--- a/components/src/main/java/org/wso2/carbon/messaging/CarbonCallback.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/CarbonCallback.java
@@ -30,5 +30,4 @@ public interface CarbonCallback {
      * @param cMsg CarbonMessage to be processed.
      */
     void done(CarbonMessage cMsg);
-
 }

--- a/components/src/main/java/org/wso2/carbon/messaging/CarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/CarbonMessage.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.messaging;
 
 import org.slf4j.Logger;

--- a/components/src/main/java/org/wso2/carbon/messaging/CarbonMessageProcessor.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/CarbonMessageProcessor.java
@@ -34,5 +34,4 @@ public interface CarbonMessageProcessor {
     void setTransportSender(TransportSender sender);
 
     String getId();
-
 }

--- a/components/src/main/java/org/wso2/carbon/messaging/DefaultCarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/DefaultCarbonMessage.java
@@ -30,5 +30,4 @@ public class DefaultCarbonMessage extends CarbonMessage {
         addMessageBody(ByteBuffer.wrap(stringMessageBody.getBytes(Charset.defaultCharset())));
         setEomAdded(true);
     }
-
 }

--- a/components/src/main/java/org/wso2/carbon/messaging/FaultHandler.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/FaultHandler.java
@@ -27,5 +27,4 @@ public interface FaultHandler {
     public void handleFault(String message, CarbonCallback carbonCallback);
 
     public void handleFault(String message, Throwable throwable, CarbonCallback carbonCallback);
-
 }

--- a/components/src/main/java/org/wso2/carbon/messaging/TransportSender.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/TransportSender.java
@@ -33,5 +33,4 @@ public interface TransportSender {
     boolean send(CarbonMessage msg, CarbonCallback callback) throws MessageProcessorException;
 
     String getId();
-
 }


### PR DESCRIPTION
This pull request is to add missing license header in CarbonMessage class and remove blank lines in other classes.
