### PR TITLE
WebSocket support for Carbon-Messaging

### DIFF
--- a/components/src/main/java/org/wso2/carbon/messaging/websocket/BinaryWebSocketCarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/websocket/BinaryWebSocketCarbonMessage.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) ${date}, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *   Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *   WSO2 Inc. licenses this file to you under the Apache License,
  *   Version 2.0 (the "License"); you may not use this file except

--- a/components/src/main/java/org/wso2/carbon/messaging/websocket/BinaryWebSocketCarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/websocket/BinaryWebSocketCarbonMessage.java
@@ -1,0 +1,58 @@
+/*
+ *   Copyright (c) ${date}, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.messaging.websocket;
+
+import java.nio.ByteBuffer;
+
+/**
+ * {@link WebSocketCarbonMessage} type for WebSocket Binary Message
+ */
+public class BinaryWebSocketCarbonMessage extends WebSocketCarbonMessage {
+
+    private ByteBuffer bytes;
+    private boolean finalFragment;
+
+    /**
+     * @param bytes byte array of binary data
+     * @param finalFragment true if the message is the final fragment of the binary message.
+     *                      First fragment can also be the final fragment
+     * @param webSocketResponder WebSocket Responder is necessary if the implementation needs WebSocket server-push.
+     *                           Otherwise leave it null
+     */
+    public BinaryWebSocketCarbonMessage(ByteBuffer bytes, boolean finalFragment,
+                                        WebSocketResponder webSocketResponder) {
+        super(webSocketResponder);
+        this.bytes = bytes;
+        this.finalFragment = finalFragment;
+    }
+
+    /**
+     * @return byte array of binary data contained in the message
+     */
+    public ByteBuffer readBytes() {
+        return bytes;
+    }
+
+    /**
+     * @return true if the message is the final fragment of the binary message
+     */
+    public boolean isFinalFragment() {
+        return finalFragment;
+    }
+}

--- a/components/src/main/java/org/wso2/carbon/messaging/websocket/CloseWebSocketCarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/websocket/CloseWebSocketCarbonMessage.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) ${date}, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *   Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *   WSO2 Inc. licenses this file to you under the Apache License,
  *   Version 2.0 (the "License"); you may not use this file except
@@ -46,7 +46,7 @@ public class CloseWebSocketCarbonMessage extends WebSocketCarbonMessage {
     }
 
     /**
-     * @return Status code of the reason to close
+     * @return Status code of the reason to close the connection
      */
     public int getStatusCode() {
         return statusCode;

--- a/components/src/main/java/org/wso2/carbon/messaging/websocket/CloseWebSocketCarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/websocket/CloseWebSocketCarbonMessage.java
@@ -1,0 +1,54 @@
+/*
+ *   Copyright (c) ${date}, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.messaging.websocket;
+
+/**
+ * {@link WebSocketCarbonMessage} type for WebSocket Close Message
+ */
+public class CloseWebSocketCarbonMessage extends WebSocketCarbonMessage {
+
+    private String reasonText;
+    private int statusCode;
+
+    /**
+     * @param statusCode Status code of reason to close
+     * @param reasonText Reason to close the connection
+     * @param webSocketResponder WebSocket Responder is necessary if the implementation needs WebSocket server-push.
+     *                           Otherwise leave it null
+     */
+    public CloseWebSocketCarbonMessage(int statusCode, String reasonText, WebSocketResponder webSocketResponder) {
+        super(webSocketResponder);
+        this.statusCode = statusCode;
+        this.reasonText = reasonText;
+    }
+
+    /**
+     * @return Reason for closing the connection
+     */
+    public String getReasonText() {
+        return reasonText;
+    }
+
+    /**
+     * @return Status code of the reason to close
+     */
+    public int getStatusCode() {
+        return statusCode;
+    }
+}

--- a/components/src/main/java/org/wso2/carbon/messaging/websocket/PingWebSocketCarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/websocket/PingWebSocketCarbonMessage.java
@@ -1,0 +1,39 @@
+/*
+ *   Copyright (c) ${date}, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.messaging.websocket;
+
+import java.nio.ByteBuffer;
+
+/**
+ * {@link WebSocketCarbonMessage} for WebSocket ping messages.
+ * This is just a extend of {@link BinaryWebSocketCarbonMessage} since all the methods are same for both.
+ */
+public class PingWebSocketCarbonMessage extends BinaryWebSocketCarbonMessage {
+    /**
+     * @param bytes              byte array of binary data
+     * @param finalFragment      true if the message is the final fragment of the binary message. First fragment can
+     *                           also be
+     *                           the final fragment
+     * @param webSocketResponder WebSocket Responder is necessary if the implementation needs WebSocket server-push.
+     */
+    public PingWebSocketCarbonMessage(ByteBuffer bytes, boolean finalFragment,
+                                      WebSocketResponder webSocketResponder) {
+        super(bytes, finalFragment, webSocketResponder);
+    }
+}

--- a/components/src/main/java/org/wso2/carbon/messaging/websocket/PingWebSocketCarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/websocket/PingWebSocketCarbonMessage.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) ${date}, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *   Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *   WSO2 Inc. licenses this file to you under the Apache License,
  *   Version 2.0 (the "License"); you may not use this file except

--- a/components/src/main/java/org/wso2/carbon/messaging/websocket/PongWebsocketCarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/websocket/PongWebsocketCarbonMessage.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) ${date}, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *   Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *   WSO2 Inc. licenses this file to you under the Apache License,
  *   Version 2.0 (the "License"); you may not use this file except

--- a/components/src/main/java/org/wso2/carbon/messaging/websocket/PongWebsocketCarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/websocket/PongWebsocketCarbonMessage.java
@@ -24,7 +24,7 @@ import java.nio.ByteBuffer;
  * {@link WebSocketCarbonMessage} for WebSocket pong messages.
  * This is just a extend of {@link BinaryWebSocketCarbonMessage} since all the methods are same for both.
  */
-public class PongWebsocketCarbonMessage extends BinaryWebSocketCarbonMessage{
+public class PongWebsocketCarbonMessage extends BinaryWebSocketCarbonMessage {
     /**
      * @param bytes              byte array of binary data
      * @param finalFragment      true if the message is the final fragment of the binary message. First fragment can

--- a/components/src/main/java/org/wso2/carbon/messaging/websocket/PongWebsocketCarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/websocket/PongWebsocketCarbonMessage.java
@@ -1,0 +1,39 @@
+/*
+ *   Copyright (c) ${date}, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.messaging.websocket;
+
+import java.nio.ByteBuffer;
+
+/**
+ * {@link WebSocketCarbonMessage} for WebSocket pong messages.
+ * This is just a extend of {@link BinaryWebSocketCarbonMessage} since all the methods are same for both.
+ */
+public class PongWebsocketCarbonMessage extends BinaryWebSocketCarbonMessage{
+    /**
+     * @param bytes              byte array of binary data
+     * @param finalFragment      true if the message is the final fragment of the binary message. First fragment can
+     *                           also be
+     *                           the final fragment
+     * @param webSocketResponder WebSocket Responder is necessary if the implementation needs WebSocket server-push.
+     */
+    public PongWebsocketCarbonMessage(ByteBuffer bytes, boolean finalFragment,
+                                      WebSocketResponder webSocketResponder) {
+        super(bytes, finalFragment, webSocketResponder);
+    }
+}

--- a/components/src/main/java/org/wso2/carbon/messaging/websocket/TextWebSocketCarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/websocket/TextWebSocketCarbonMessage.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) ${date}, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *   Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *   WSO2 Inc. licenses this file to you under the Apache License,
  *   Version 2.0 (the "License"); you may not use this file except

--- a/components/src/main/java/org/wso2/carbon/messaging/websocket/TextWebSocketCarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/websocket/TextWebSocketCarbonMessage.java
@@ -1,0 +1,46 @@
+/*
+ *   Copyright (c) ${date}, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.messaging.websocket;
+
+
+/**
+ * {@link WebSocketCarbonMessage} type for WebSocket Text Message
+ */
+public class TextWebSocketCarbonMessage extends WebSocketCarbonMessage {
+
+    private final String text;
+
+    /**
+     * @param text Text Message
+     * @param webSocketResponder WebSocket Responder is necessary if the implementation needs WebSocket server-push.
+     *                           Otherwise leave it null
+     */
+    public TextWebSocketCarbonMessage(String text, WebSocketResponder webSocketResponder) {
+        super(webSocketResponder);
+        this.text = text;
+    }
+
+    /**
+     * @return String included in WebSocket Text Message
+     */
+    public String getText() {
+        return text;
+    }
+
+}

--- a/components/src/main/java/org/wso2/carbon/messaging/websocket/WebSocketCarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/websocket/WebSocketCarbonMessage.java
@@ -1,0 +1,38 @@
+/*
+ *   Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.messaging.websocket;
+
+import org.wso2.carbon.messaging.CarbonMessage;
+
+/**
+ * {@link CarbonMessage} type of WebSocket Messages
+ */
+public class WebSocketCarbonMessage extends CarbonMessage {
+
+    private WebSocketResponder webSocketResponder;
+
+
+    public WebSocketCarbonMessage(WebSocketResponder webSocketResponder) {
+        this.webSocketResponder = webSocketResponder;
+    }
+
+    public WebSocketResponder getWebSocketResponder() {
+        return webSocketResponder;
+    }
+}

--- a/components/src/main/java/org/wso2/carbon/messaging/websocket/WebSocketResponder.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/websocket/WebSocketResponder.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) ${date}, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *   Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *   WSO2 Inc. licenses this file to you under the Apache License,
  *   Version 2.0 (the "License"); you may not use this file except

--- a/components/src/main/java/org/wso2/carbon/messaging/websocket/WebSocketResponder.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/websocket/WebSocketResponder.java
@@ -1,0 +1,31 @@
+/*
+ *   Copyright (c) ${date}, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.messaging.websocket;
+
+/**
+ * Server-side responder for WebSocket Connection
+ */
+public interface WebSocketResponder {
+
+    /**
+     * Pushes server events to the client
+     * @param webSocketCarbonMessage Any kind of {@link WebSocketCarbonMessage} which needs to push to the client
+     */
+    void pushToClient(WebSocketCarbonMessage webSocketCarbonMessage);
+}


### PR DESCRIPTION
The current implementation of carbon-messaging does not support WebSocket messaging.
We need to add WebSocket support to carbon-messaging in order to decouple [Carbon-Transport](https://github.com/wso2/carbon-transports) from [WSO2 MSF4J](https://github.com/wso2/msf4j).

So in order to get support,
new **CarbonMessage** was created called **WebSocketCarbonMessage**

WebSocketCarbonMessage was extended and **added new types of WebSocketCarbonMessages** 

- **TextWebSocketCarbonMessage**

- **BinaryWebSocketCarbonMessage** 

- **CloseWebSocketCarbonMessage** 

- **PingWebSocketCarbonMessage** 

- **PongWebSocketCarbonMessage** 

Also, new Interface was added **WebSocketResponder** to handle WebSocket responses. It is a necessary Component to construct a WebSocketCarbonMessage since the WebSocket responses cannot be handled by HTTP request-response messaging.
eg : WebSocket can do server pushes without client requests

resolves #38 