### PR TITLE
Added new message types to handle different kinds of data.

### DIFF
--- a/components/pom.xml
+++ b/components/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.wso2.carbon.messaging</groupId>
         <artifactId>org.wso2.carbon.messaging.parent</artifactId>
-        <version>1.0.12-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.messaging</artifactId>
     <packaging>bundle</packaging>
-    <version>1.0.12-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <name>WSO2 Carbon Messaging Component</name>
 
     <dependencies>

--- a/components/src/main/java/org/wso2/carbon/messaging/BinaryCarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/BinaryCarbonMessage.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.messaging;
+
+import java.nio.ByteBuffer;
+
+/**
+ * {@link CarbonMessage} type for Binary Messages. This message type handles the binary data easily. So if you are
+ * dealing with binary data it is better to use this message type. This will work as a binary data carrier from
+ * transport level to application level.
+ */
+public class BinaryCarbonMessage extends CarbonMessage {
+
+    private ByteBuffer bytes; //ByteBuffer to store binary data
+    private boolean finalFragment; //Check whether given fragment is final when partial messages are sent
+
+    /**
+     * @param bytes byte array of binary data.
+     * @param finalFragment true if the message is the final fragment of the binary message.
+     *                      First fragment can also be the final fragment.
+     */
+    public BinaryCarbonMessage(ByteBuffer bytes, boolean finalFragment) {
+        this.bytes = bytes;
+        this.finalFragment = finalFragment;
+    }
+
+    /**
+     * @return byte array of binary data contained in the message.
+     */
+    public ByteBuffer readBytes() {
+        return bytes;
+    }
+
+    /**
+     * @return true if the message is the final fragment of the binary message.
+     */
+    public boolean isFinalFragment() {
+        return finalFragment;
+    }
+}

--- a/components/src/main/java/org/wso2/carbon/messaging/Constants.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/Constants.java
@@ -56,7 +56,9 @@ public final class Constants {
 
     public static final String LISTENER_INTERFACE_ID = "LISTENER_INTERFACE_ID";
 
-
+    //Status of a status message
+    public static final String STATUS_OPEN = "STATUS_OPEN";
+    public static final String STATUS_CLOSE = "STATUS_CLOSE";
 
     private Constants() {
     }

--- a/components/src/main/java/org/wso2/carbon/messaging/ControlCarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/ControlCarbonMessage.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.messaging;
+
+import java.nio.ByteBuffer;
+
+/**
+ * {@link CarbonMessage} for control messages. This is used for control messages of a connection.
+ * This is just a extend of {@link BinaryCarbonMessage} since all the methods are same for both.
+ * This message type is useful when you need to send control messages for a given connection.
+ */
+public class ControlCarbonMessage extends BinaryCarbonMessage {
+    /**
+     * @param bytes              byte array of binary data.
+     * @param finalFragment      true if the message is the final fragment of the binary message. First fragment can
+     *                           also be the final fragment.
+     */
+    public ControlCarbonMessage(ByteBuffer bytes, boolean finalFragment) {
+        super(bytes, finalFragment);
+    }
+}

--- a/components/src/main/java/org/wso2/carbon/messaging/StatusCarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/StatusCarbonMessage.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.messaging;
+
+/**
+ * {@link CarbonMessage} type for Status Message. This contains a status, status code and if prefers a reason text.
+ * This is a useful message type to know about the status of a connection. If you have to process something when
+ * the status of a connection is changed use this message type to transfer all the necessary details.
+ */
+public class StatusCarbonMessage extends CarbonMessage {
+
+    private final String status;
+    private final String reasonText; //Reason saying why the connection is closed
+    private final int statusCode; //Status code of the connection close
+
+    /**
+     * @param statusCode Status code of reason to close.
+     * @param reasonText Reason to close the connection.
+     */
+    public StatusCarbonMessage(String status, int statusCode, String reasonText) {
+        this.status = status;
+        this.statusCode = statusCode;
+        this.reasonText = reasonText;
+    }
+
+    /**
+     * @return the status of a connection
+     */
+    public String getStatus() {
+        return status;
+    }
+
+    /**
+     * @return Reason for closing the connection.
+     */
+    public String getReasonText() {
+        return reasonText;
+    }
+
+    /**
+     * @return Status code of the reason to close the connection.
+     */
+    public int getStatusCode() {
+        return statusCode;
+    }
+}

--- a/components/src/main/java/org/wso2/carbon/messaging/TextCarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/TextCarbonMessage.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.messaging;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * {@link CarbonMessage} type for Text Messages. This message type is better if you are dealing with
+ * text data. This will work as the text data carrier from transport level to application level.
+ */
+public class TextCarbonMessage extends CarbonMessage {
+
+    private final String text;
+
+    /**
+     * @param text Text Message
+     */
+    public TextCarbonMessage(String text) {
+        this.text = text;
+    }
+
+    /**
+     * @return String included in Text Message.
+     */
+    public String getText() {
+        return text;
+    }
+    
+    @Override
+    public InputStream getInputStream() {
+        if (text == null) {
+            return null;
+        }
+        return new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wso2.carbon.messaging</groupId>
         <artifactId>org.wso2.carbon.messaging.parent</artifactId>
-        <version>1.0.12-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <groupId>org.wso2.carbon.messaging</groupId>
     <artifactId>org.wso2.carbon.messaging.parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.12-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <name>WSO2 Carbon Messaging Parent</name>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -85,9 +85,9 @@
 
         <carbon.feature.plugin.version>2.0.1</carbon.feature.plugin.version>
 
-        <carbon.messaging.version>1.0.12-SNAPSHOT</carbon.messaging.version>
+        <carbon.messaging.version>1.1.0-SNAPSHOT</carbon.messaging.version>
 
-        <carbon.messaging.package.export.version>1.0.11</carbon.messaging.package.export.version>
+        <carbon.messaging.package.export.version>1.1.0</carbon.messaging.package.export.version>
 
         <!--following versions are used in the parent pom-->
         <wso2.maven.compiler.source>1.8</wso2.maven.compiler.source>


### PR DESCRIPTION
The current implementation of carbon-messaging does not support WebSocket messaging.
We need to add WebSocket support to carbon-messaging in order to decouple [Carbon-Transport](https://github.com/wso2/carbon-transports) from [WSO2 MSF4J](https://github.com/wso2/msf4j).

So in order to get support,
New Carbon Message types are added to Carbon-Messaging. These can be used in any protocol which matches to the content of the message.

- **TextCarbonMessage**

- **BinaryCarbonMessage**

- **StatusCarbonMessage**

- **ControlCarbonMessage**

This will carry minor version change for new message types

resolves #38
