### PR TITLE
Fix issue when cloning message

### DIFF
--- a/components/src/main/java/org/wso2/carbon/messaging/CarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/CarbonMessage.java
@@ -225,7 +225,14 @@ public abstract class CarbonMessage {
         List<ByteBuffer> newCopy = fullMessageBody.stream().map(byteBuffer -> MessageUtil.deepCopy(byteBuffer))
                 .collect(Collectors.toList());
         fullMessageBody.forEach(byteBuffer -> addMessageBody(byteBuffer));
+        markMessageEnd();
         return newCopy;
+    }
+
+    /**
+     * This method is used to mark the end of the message when cloning the content.
+     */
+    public void markMessageEnd() {
     }
 
     public void setEndOfMsgAdded(boolean endOfMsgAdded) {


### PR DESCRIPTION
Relevant message provider should implement the method to mark the end of the message.