### PR TITLE
Overriding the input stream in serializable carbon message

### DIFF
--- a/components/pom.xml
+++ b/components/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.wso2.carbon.messaging</groupId>
         <artifactId>org.wso2.carbon.messaging.parent</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>2.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.messaging</artifactId>
     <packaging>bundle</packaging>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0</version>
     <name>WSO2 Carbon Messaging Component</name>
 
     <dependencies>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.wso2.carbon.messaging</groupId>
         <artifactId>org.wso2.carbon.messaging.parent</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.messaging</artifactId>
     <packaging>bundle</packaging>
-    <version>2.2.1</version>
+    <version>2.2.2-SNAPSHOT</version>
     <name>WSO2 Carbon Messaging Component</name>
 
     <dependencies>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.wso2.carbon.messaging</groupId>
         <artifactId>org.wso2.carbon.messaging.parent</artifactId>
-        <version>2.2.0</version>
+        <version>2.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.messaging</artifactId>
     <packaging>bundle</packaging>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
     <name>WSO2 Carbon Messaging Component</name>
 
     <dependencies>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.wso2.carbon.messaging</groupId>
         <artifactId>org.wso2.carbon.messaging.parent</artifactId>
-        <version>2.2.2</version>
+        <version>2.2.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.messaging</artifactId>
     <packaging>bundle</packaging>
-    <version>2.2.2</version>
+    <version>2.2.3-SNAPSHOT</version>
     <name>WSO2 Carbon Messaging Component</name>
 
     <dependencies>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.wso2.carbon.messaging</groupId>
         <artifactId>org.wso2.carbon.messaging.parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.2.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.messaging</artifactId>
     <packaging>bundle</packaging>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.1</version>
     <name>WSO2 Carbon Messaging Component</name>
 
     <dependencies>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.wso2.carbon.messaging</groupId>
         <artifactId>org.wso2.carbon.messaging.parent</artifactId>
-        <version>2.2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>org.wso2.carbon.messaging</artifactId>
     <packaging>bundle</packaging>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.2.2</version>
     <name>WSO2 Carbon Messaging Component</name>
 
     <dependencies>

--- a/components/src/main/java/org/wso2/carbon/messaging/CarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/CarbonMessage.java
@@ -225,7 +225,14 @@ public abstract class CarbonMessage {
         List<ByteBuffer> newCopy = fullMessageBody.stream().map(byteBuffer -> MessageUtil.deepCopy(byteBuffer))
                 .collect(Collectors.toList());
         fullMessageBody.forEach(byteBuffer -> addMessageBody(byteBuffer));
+        markMessageEnd();
         return newCopy;
+    }
+
+    /**
+     * This method is used to mark the end of the message when cloning the content.
+     */
+    public void markMessageEnd() {
     }
 
     public void setEndOfMsgAdded(boolean endOfMsgAdded) {

--- a/components/src/main/java/org/wso2/carbon/messaging/CarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/CarbonMessage.java
@@ -319,7 +319,7 @@ public abstract class CarbonMessage {
 
         @Override
         public int read() throws IOException {
-            setAlreadyRead(true);
+            setAlreadyRead(true); // TODO: No need to set this again and again
             if (isEndOfMsgAdded() && isEmpty() && chunkFinished) {
                 return -1;
             } else if (chunkFinished) {

--- a/components/src/main/java/org/wso2/carbon/messaging/Header.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/Header.java
@@ -44,4 +44,8 @@ public class Header {
     public void setValue(String value) {
         this.value = value;
     }
+
+    public Header getClone() {
+       return new Header(name, value);
+    }
 }

--- a/components/src/main/java/org/wso2/carbon/messaging/Headers.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/Headers.java
@@ -102,6 +102,15 @@ public class Headers {
         return headerList;
     }
 
+    public List<Header> getClone() {
+        List<Header> clonedHeaderList = new LinkedList<>();
+
+        headerList.forEach(header -> {
+            clonedHeaderList.add(header.getClone());
+        });
+        return clonedHeaderList;
+    }
+
     /**
      * This will return a values fo given header name regardless of case sensitivity as a LikedList.
      * @param name name of the header

--- a/components/src/main/java/org/wso2/carbon/messaging/MessageUtil.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/MessageUtil.java
@@ -37,7 +37,7 @@ public class MessageUtil {
 
         CarbonMessage newCarbonMessage = new DefaultCarbonMessage(carbonMessage.isBufferContent());
 
-        List<Header> transportHeaders = carbonMessage.getHeaders().getAll();
+        List<Header> transportHeaders = carbonMessage.getHeaders().getClone();
 
         newCarbonMessage.setHeaders(transportHeaders);
 

--- a/components/src/main/java/org/wso2/carbon/messaging/MessageUtil.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/MessageUtil.java
@@ -60,7 +60,7 @@ public class MessageUtil {
 
         CarbonMessage newCarbonMessage = new DefaultCarbonMessage(carbonMessage.isBufferContent());
 
-        List<Header> transportHeaders = carbonMessage.getHeaders().getAll();
+        List<Header> transportHeaders = carbonMessage.getHeaders().getClone();
 
         newCarbonMessage.setHeaders(transportHeaders);
 

--- a/components/src/main/java/org/wso2/carbon/messaging/SerializableCarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/SerializableCarbonMessage.java
@@ -17,7 +17,10 @@
  */
 package org.wso2.carbon.messaging;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
 /**
@@ -83,5 +86,13 @@ public class SerializableCarbonMessage extends CarbonMessage implements Serializ
      */
     public void setPayloadType(String payloadType) {
         this.payloadType = payloadType;
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        if (payload == null) {
+            return null;
+        }
+        return new ByteArrayInputStream(payload.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wso2.carbon.messaging</groupId>
         <artifactId>org.wso2.carbon.messaging.parent</artifactId>
-        <version>2.2.2-SNAPSHOT</version>
+        <version>2.2.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wso2.carbon.messaging</groupId>
         <artifactId>org.wso2.carbon.messaging.parent</artifactId>
-        <version>2.2.2</version>
+        <version>2.2.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wso2.carbon.messaging</groupId>
         <artifactId>org.wso2.carbon.messaging.parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.2.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wso2.carbon.messaging</groupId>
         <artifactId>org.wso2.carbon.messaging.parent</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wso2.carbon.messaging</groupId>
         <artifactId>org.wso2.carbon.messaging.parent</artifactId>
-        <version>2.2.0</version>
+        <version>2.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wso2.carbon.messaging</groupId>
         <artifactId>org.wso2.carbon.messaging.parent</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>2.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,14 @@
     <groupId>org.wso2.carbon.messaging</groupId>
     <artifactId>org.wso2.carbon.messaging.parent</artifactId>
     <packaging>pom</packaging>
-    <version>2.2.1</version>
+    <version>2.2.2-SNAPSHOT</version>
     <name>WSO2 Carbon Messaging Parent</name>
 
     <scm>
         <url>https://github.com/wso2/carbon-messaging.git</url>
         <developerConnection>scm:git:https://github.com/wso2/carbon-messaging.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/carbon-messaging.git</connection>
-        <tag>v2.2.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <dependencyManagement>
@@ -85,7 +85,7 @@
 
         <carbon.feature.plugin.version>2.0.1</carbon.feature.plugin.version>
 
-        <carbon.messaging.version>2.2.1</carbon.messaging.version>
+        <carbon.messaging.version>2.2.2-SNAPSHOT</carbon.messaging.version>
 
         <carbon.messaging.package.export.version>2.0.0</carbon.messaging.package.export.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,14 @@
     <groupId>org.wso2.carbon.messaging</groupId>
     <artifactId>org.wso2.carbon.messaging.parent</artifactId>
     <packaging>pom</packaging>
-    <version>2.2.2</version>
+    <version>2.2.3-SNAPSHOT</version>
     <name>WSO2 Carbon Messaging Parent</name>
 
     <scm>
         <url>https://github.com/wso2/carbon-messaging.git</url>
         <developerConnection>scm:git:https://github.com/wso2/carbon-messaging.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/carbon-messaging.git</connection>
-        <tag>v2.2.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <dependencyManagement>
@@ -85,7 +85,7 @@
 
         <carbon.feature.plugin.version>2.0.1</carbon.feature.plugin.version>
 
-        <carbon.messaging.version>2.2.2</carbon.messaging.version>
+        <carbon.messaging.version>2.2.3-SNAPSHOT</carbon.messaging.version>
 
         <carbon.messaging.package.export.version>2.0.0</carbon.messaging.package.export.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,14 @@
     <groupId>org.wso2.carbon.messaging</groupId>
     <artifactId>org.wso2.carbon.messaging.parent</artifactId>
     <packaging>pom</packaging>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.2.2</version>
     <name>WSO2 Carbon Messaging Parent</name>
 
     <scm>
         <url>https://github.com/wso2/carbon-messaging.git</url>
         <developerConnection>scm:git:https://github.com/wso2/carbon-messaging.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/carbon-messaging.git</connection>
-        <tag>HEAD</tag>
+        <tag>v2.2.2</tag>
     </scm>
 
     <dependencyManagement>
@@ -85,7 +85,7 @@
 
         <carbon.feature.plugin.version>2.0.1</carbon.feature.plugin.version>
 
-        <carbon.messaging.version>2.2.2-SNAPSHOT</carbon.messaging.version>
+        <carbon.messaging.version>2.2.2</carbon.messaging.version>
 
         <carbon.messaging.package.export.version>2.0.0</carbon.messaging.package.export.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,14 @@
     <groupId>org.wso2.carbon.messaging</groupId>
     <artifactId>org.wso2.carbon.messaging.parent</artifactId>
     <packaging>pom</packaging>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.1</version>
     <name>WSO2 Carbon Messaging Parent</name>
 
     <scm>
         <url>https://github.com/wso2/carbon-messaging.git</url>
         <developerConnection>scm:git:https://github.com/wso2/carbon-messaging.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/carbon-messaging.git</connection>
-        <tag>HEAD</tag>
+        <tag>v2.2.1</tag>
     </scm>
 
     <dependencyManagement>
@@ -85,7 +85,7 @@
 
         <carbon.feature.plugin.version>2.0.1</carbon.feature.plugin.version>
 
-        <carbon.messaging.version>2.2.1-SNAPSHOT</carbon.messaging.version>
+        <carbon.messaging.version>2.2.1</carbon.messaging.version>
 
         <carbon.messaging.package.export.version>2.0.0</carbon.messaging.package.export.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,14 @@
     <groupId>org.wso2.carbon.messaging</groupId>
     <artifactId>org.wso2.carbon.messaging.parent</artifactId>
     <packaging>pom</packaging>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
     <name>WSO2 Carbon Messaging Parent</name>
 
     <scm>
         <url>https://github.com/wso2/carbon-messaging.git</url>
         <developerConnection>scm:git:https://github.com/wso2/carbon-messaging.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/carbon-messaging.git</connection>
-        <tag>v2.2.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <dependencyManagement>
@@ -85,7 +85,7 @@
 
         <carbon.feature.plugin.version>2.0.1</carbon.feature.plugin.version>
 
-        <carbon.messaging.version>2.2.0</carbon.messaging.version>
+        <carbon.messaging.version>2.2.1-SNAPSHOT</carbon.messaging.version>
 
         <carbon.messaging.package.export.version>2.0.0</carbon.messaging.package.export.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,14 @@
     <groupId>org.wso2.carbon.messaging</groupId>
     <artifactId>org.wso2.carbon.messaging.parent</artifactId>
     <packaging>pom</packaging>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0</version>
     <name>WSO2 Carbon Messaging Parent</name>
 
     <scm>
         <url>https://github.com/wso2/carbon-messaging.git</url>
         <developerConnection>scm:git:https://github.com/wso2/carbon-messaging.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/carbon-messaging.git</connection>
-        <tag>HEAD</tag>
+        <tag>v2.2.0</tag>
     </scm>
 
     <dependencyManagement>
@@ -85,7 +85,7 @@
 
         <carbon.feature.plugin.version>2.0.1</carbon.feature.plugin.version>
 
-        <carbon.messaging.version>2.2.0-SNAPSHOT</carbon.messaging.version>
+        <carbon.messaging.version>2.2.0</carbon.messaging.version>
 
         <carbon.messaging.package.export.version>2.0.0</carbon.messaging.package.export.version>
 


### PR DESCRIPTION
This fixes issue in getting the input stream from serializable carbon message.

This PR and https://github.com/wso2/carbon-transports/pull/203 will fix message conversion