### PR TITLE
Add methods to MessageUtil class

### DIFF
--- a/components/src/main/java/org/wso2/carbon/messaging/MapCarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/MapCarbonMessage.java
@@ -65,4 +65,11 @@ public class MapCarbonMessage extends CarbonMessage {
     public Enumeration<String> getMapNames() {
         return Collections.enumeration(mapData.keySet());
     }
+
+    /**
+     * Clear internal payload of the message
+     */
+    public void clearMapPayload() {
+        mapData = new HashMap<>();
+    }
 }

--- a/components/src/main/java/org/wso2/carbon/messaging/MessageUtil.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/MessageUtil.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.messaging;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -109,4 +110,34 @@ public class MessageUtil {
         }
     }
 
+    /**
+     * Creates a {@link MapCarbonMessage} using a {@link CarbonMessage}. Internal Map content is
+     * not populated when {@link MapCarbonMessage} is constructed.
+     *
+     * @param carbonMessage {@link CarbonMessage}
+     */
+    public static MapCarbonMessage createMapMessageWithoutData(CarbonMessage carbonMessage) {
+        MapCarbonMessage mapCarbonMessage = new MapCarbonMessage();
+        mapCarbonMessage.setHeaders(new ArrayList<>(carbonMessage.headers.getAll()));
+        carbonMessage.getProperties().forEach(mapCarbonMessage::setProperty);
+        mapCarbonMessage.setWriter(carbonMessage.getWriter());
+        mapCarbonMessage.setFaultHandlerStack(carbonMessage.getFaultHandlerStack());
+        return mapCarbonMessage;
+    }
+
+    /**
+     * Creates a {@link TextCarbonMessage} using a {@link CarbonMessage}.
+     *
+     * @param message {@link CarbonMessage}
+     * @return TextCarbonMessage
+     */
+    public static TextCarbonMessage createTextMessageWithData(CarbonMessage message) {
+        TextCarbonMessage textCarbonMessage =
+                new TextCarbonMessage(message.getMessageDataSource().getMessageAsString());
+        textCarbonMessage.setHeaders(new ArrayList<>(message.headers.getAll()));
+        message.getProperties().forEach(textCarbonMessage::setProperty);
+        textCarbonMessage.setWriter(message.getWriter());
+        textCarbonMessage.setFaultHandlerStack(message.getFaultHandlerStack());
+        return textCarbonMessage;
+    }
 }

--- a/components/src/main/java/org/wso2/carbon/messaging/TextCarbonMessage.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/TextCarbonMessage.java
@@ -43,7 +43,7 @@ public class TextCarbonMessage extends CarbonMessage {
     public String getText() {
         return text;
     }
-    
+
     @Override
     public InputStream getInputStream() {
         if (text == null) {


### PR DESCRIPTION
- Add MessageUtil methods to create MapCarbonMessage and TextCarbonMessage instance using and existing CarbonMessage.
- Add a method to clear MapCarbonMessage payload.