### PR TITLE
Add error handler as an instance variable of server connector

### DIFF
--- a/components/src/main/java/org/wso2/carbon/messaging/ServerConnector.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/ServerConnector.java
@@ -38,6 +38,8 @@ public abstract class ServerConnector {
 
     protected Map<String, String> properties;
 
+    protected ServerConnectorErrorHandler errorHandler;
+
     public ServerConnector(String id, Map<String, String> properties) {
         this.id = id;
         this.properties = properties;
@@ -56,6 +58,22 @@ public abstract class ServerConnector {
      * @param messageProcessor message processor instance
      */
     public abstract void setMessageProcessor(CarbonMessageProcessor messageProcessor);
+
+    /**
+     * Set the error handler to be used with this connector
+     * @param errorHandler error handler instance
+     */
+    public void setServerConnectorErrorHandler(ServerConnectorErrorHandler errorHandler) {
+        this.errorHandler = errorHandler;
+    }
+
+    /**
+     * Returns the error handler associated with this connector
+     * @return error handler instance
+     */
+    public ServerConnectorErrorHandler getServerConnectorErrorHandler() {
+        return errorHandler;
+    }
 
     /**
      * Returns the id of the connector.

--- a/components/src/main/java/org/wso2/carbon/messaging/ServerConnectorErrorHandler.java
+++ b/components/src/main/java/org/wso2/carbon/messaging/ServerConnectorErrorHandler.java
@@ -30,9 +30,8 @@ public interface ServerConnectorErrorHandler {
      * @param exception error thrown from the application level to be handled.
      * @param carbonMessage the carbonMessage associated with the currently request/response flow
      * @param callback the callback used with responding
-     * @throws Exception thrown, if the error could not be handled.
      */
-    void handleError(Exception exception, CarbonMessage carbonMessage, CarbonCallback callback) throws Exception;
+    void handleError(Exception exception, CarbonMessage carbonMessage, CarbonCallback callback);
 
     /**
      * Returns the string value of the transport protocol (eg: "http", "jms", etc. ) this listener is bound to.


### PR DESCRIPTION
This PR add the ability to set an error handler to the server connector which can then be used to handle errors related to server connectors. 